### PR TITLE
Set GH_ACCESS_TOKEN when building docker images

### DIFF
--- a/.github/workflows/resourcely-cli.yml
+++ b/.github/workflows/resourcely-cli.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Build resourcely-cli Docker image
       run: |
-        docker build -t $IMAGE_NAME_CLI resourcely-cli
+        docker build -t $IMAGE_NAME_CLI --build-arg="GH_ACCESS_TOKEN=${{ secrets.GH_ACCESS_TOKEN }}" resourcely-cli
         docker images # for debugging purposes
 
     # Login and push resourcely-cli image

--- a/.github/workflows/wait-for-terraform.yml
+++ b/.github/workflows/wait-for-terraform.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Build wait-for-terraform-plan Docker image
       run: |
-        docker build -t $IMAGE_NAME_TF_PLAN wait-for-terraform-plan
+        docker build -t $IMAGE_NAME_TF_PLAN --build-arg="GH_ACCESS_TOKEN=${{ secrets.GH_ACCESS_TOKEN }}" wait-for-terraform-plan
         docker images # for debugging purposes
 
     # Login and push both images


### PR DESCRIPTION
## What?

Pass build argument `GH_ACCESS_TOKEN` to Docker builds.

## Why?

Docker build of `resourcely-cli` fails while trying to  compile our application ([example](https://github.com/Resourcely-Inc/resourcely-container-registry/actions/runs/6320783113/job/17163801782#step:3:148)).  This started happening with the most recent change, which [added our protos repository](https://github.com/Resourcely-Inc/resourcely-cli/pull/27/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R26) as a dependency, requiring a Resourcely token to complete successfully.

I suspect that even though we are setting the env variable in the pipeline, and we're reading it [within the container](https://github.com/Resourcely-Inc/resourcely-cli/blob/ebde9f1092907318972c01c397a43ff46e9e1c0f/Dockerfile#L8), it's not getting passed into the Docker container.  Hence the error:

> could not read Password for github.com